### PR TITLE
Fix issues related to Markdown link and image

### DIFF
--- a/en/ios-authentication.md
+++ b/en/ios-authentication.md
@@ -959,7 +959,7 @@ Instant withdrawal cannot be undone, so it is important to ask the user several 
 
 
 * For the entire list of error codes, see the following document.
-    - [Error Code] (./error-code/#client-sdk)
+    - [Error Code](./error-code/#client-sdk)
 
 
 **TCGB\_ERROR\_AUTH\_EXTERNAL\_LIBRARY\_ERROR**

--- a/en/ios-etc.md
+++ b/en/ios-etc.md
@@ -742,7 +742,7 @@ Gamebase provides features to respond to customer inquiries.
 >
 > Associate it with the NHN Cloud Contact service to easily respond to inquiries from customers.
 > See the guide below if you want to know how to use the NHN Cloud Contact service in detail.
-> [NHN Cloud Online Contact Guide] (/Contact%20Center/ko/online-contact-overview/)
+> [NHN Cloud Online Contact Guide](/Contact%20Center/en/online-contact-overview/)
 >
 
 #### Customer Service Type

--- a/en/ios-push.md
+++ b/en/ios-push.md
@@ -20,7 +20,7 @@ This document describes the process of creating Apple developer certificates req
 * The password you used to create the above certificate will be used for registration.
 
 #### Implementing Notification Service Extension
-* For tasks such as collecting inbound indicators and setting the notification sound, see [NHN Cloud Push Guide](https://docs.toast.com/ko/TOAST/ko/toast-sdk/push-ios/#notification-service-extension) to implement the **Notification Service Extension** for the application.
+* For tasks such as collecting inbound indicators and setting the notification sound, see [NHN Cloud Push Guide](https://docs.toast.com/en/TOAST/en/toast-sdk/push-ios/#notification-service-extension) to implement the **Notification Service Extension** for the application.
 
 
 #### Setting up Xcode Project

--- a/en/js-authentication.md
+++ b/en/js-authentication.md
@@ -417,5 +417,5 @@ function withdrawImmediately() {
 | Auth(Unknown)  | AUTH\_UNKNOWN\_ERROR                                    | 3999       | An unknown error occurred (undefined error).                             |
 
 * For the entire list of error codes, see the following document.
-    * [Entire Error Codes] (./error-code/#client-sdk)
+    * [Entire Error Codes](./error-code/#client-sdk)
     

--- a/en/js-initialization.md
+++ b/en/js-initialization.md
@@ -161,7 +161,7 @@ See the table below for status code:
 | INSPECTING_ALL_SERVICES     | 304  | All services in maintenance                              |
 | INTERNAL_SERVER_ERROR       | 500  | Internal server error                                 |
 
-[Console Guide] (/Game/Gamebase/ko/oper-app/#app)
+[Console Guide](/Game/Gamebase/en/oper-app/#app)
 
 **1.2 App**
 
@@ -178,7 +178,7 @@ App information registered in the Gamebase Console.
 * install: Installation URL
 * idP: Authentication information
 
-[Console Guide] (/Game/Gamebase/ko/oper-app/#client)
+[Console Guide](/Game/Gamebase/en/oper-app/#client)
 
 **1.3 Maintenance**
 
@@ -190,7 +190,7 @@ Maintenance information registered in the Gamebase Console.
 * endDate: End time
 * message: Reason for maintenance
 
-[Console Guide] (/Game/Gamebase/ko/oper-operation/#maintenance)
+[Console Guide](/Game/Gamebase/en/oper-operation/#maintenance)
 
 **1.4 Notice**
 
@@ -200,7 +200,7 @@ Notification information registered in the Gamebase Console.
 * title: Title
 * url: Maintenance URL
 
-[Console Guide] (/Game/Gamebase/ko/oper-operation/#notice)
+[Console Guide](/Game/Gamebase/en/oper-operation/#notice)
 
 #### 2. tcProduct
 
@@ -219,7 +219,7 @@ The IAP store information registered in the NHN Cloud Console.
 * name: App Name
 * storeCode: Store Code
  
-[Console Guide] (/Game/Gamebase/ko/oper-purchase/)
+[Console Guide](/Game/Gamebase/en/oper-purchase/)
 
 #### 4. tcLaunching
 
@@ -227,7 +227,7 @@ Launching information registered in the NHN Cloud Console.
 
 * The value entered by users in Console is sent as a JSON string.
  
-[Console Guide] (/Game/Gamebase/ko/oper-management/#config)
+[Console Guide](/Game/Gamebase/en/oper-management/#config)
 
 
 ### Error Handling
@@ -243,4 +243,4 @@ Launching information registered in the NHN Cloud Console.
 
 
 * For the entire list of error codes, see the following document.
-    * [Error Code] (./error-code/#client-sdk)
+    * [Error Code](./error-code/#client-sdk)

--- a/en/oper-analytics.md
+++ b/en/oper-analytics.md
@@ -132,7 +132,7 @@ By opting for the exclusion of withdrawer on the same day of subscription, you c
       e.g.) Out of 100 new users on January 1st, 20 withdrew on January 1st: then, the number of actual new users is calculated at 80 (100-20).
       
 ### LTV
-![gamebase_analytics_06_201912_1_ltv] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_201912_1_ltv.png)
+![gamebase_analytics_06_201912_1_ltv](https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_201912_1_ltv.png)
 
 LTV is an index representing the expected annual revenue from a single user in the selected user group.
 
@@ -156,7 +156,7 @@ The following restrictions are applied for accurate estimation of LTV:
 * The most recent signed-up date must be more than 7 days.
 
 ### Life Cycle
-![gamebase_analytics_06_202002_1_lifeCycle] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_202002_1_lifeCycle.png)
+![gamebase_analytics_06_202002_1_lifeCycle](https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_202002_1_lifeCycle.png)
 
 Life Cycle is an index used to check the trend of daily active users since the first inflow of users. Data is retained for up to 3 years.
 
@@ -170,7 +170,7 @@ Life Cycle is an index used to check the trend of daily active users since the f
 
 ### Frequency7
 
-![gamebase_analytics_06_202003_1_frequency] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_202003_1_frequency.png)
+![gamebase_analytics_06_202003_1_frequency](https://static.toastoven.net/prod_gamebase/gamebase_analytics_06_202003_1_frequency.png)
 
 The Frequency7 index provides information about weekly visitor and ratio of DAU. It can be used to see immersion, loyalty, and other information at a glance.
 

--- a/en/oper-app.md
+++ b/en/oper-app.md
@@ -133,13 +133,13 @@ The options to be set are as follows:
 
 ### Test Device
 
-![gamebase_app_02_201812.png] (http://static.toastoven.net/prod_gamebase/gamebase_app_02_201912.png)
+![gamebase_app_02_201812.png](http://static.toastoven.net/prod_gamebase/gamebase_app_02_201912.png)
 If it is registered as a test device, it can access the game as usual even when the app running Gamebase is under maintenance.
 You need to register **Device Key** or **IP** information to register a test device. You can register it by directly entering the information or retrieving **Game User ID**.
 Test devices can be managed by allowing them to be able to access the game even when it is under maintenance or configuring whether to display the debug log on each device.
 You can also delete test devices that you don't use anymore.
 Click the Access History button to check **Connected Time and Detailed Connection Log during Maintenance** via the device.
-![gamebase_app_02_201812.png] (http://static.toastoven.net/prod_gamebase/gamebase_app_09_201912.png)
+![gamebase_app_02_201812.png](http://static.toastoven.net/prod_gamebase/gamebase_app_09_201912.png)
 
 > [Note]
 > Up to 100 test devices can be registered.
@@ -152,7 +152,7 @@ Can check all test devices registered with the app. Enter a keyword in the **Sea
 
 Click the **Register** button on the Search screen to access the screen where test devices can be registered. Manually enter **Device Key** or search for **Game User ID** and register a test device.
 
-![gamebase_app_02_201812.png] (http://static.toastoven.net/prod_gamebase/gamebase_app_10_201912.png)
+![gamebase_app_02_201812.png](http://static.toastoven.net/prod_gamebase/gamebase_app_10_201912.png)
 ![gamebase_app_02_201812.png](http://static.toastoven.net/prod_gamebase/gamebase_app_11_201912.png)
 
 **(1) Register using Game User ID**
@@ -171,7 +171,7 @@ Enter **Device Name**, debug log, and whether to ignore maintenance of the devic
 
 #### (3) Delete
 
-![gamebase_app_02_201812.png] (http://static.toastoven.net/prod_gamebase/gamebase_app_12_201912.png)
+![gamebase_app_02_201812.png](http://static.toastoven.net/prod_gamebase/gamebase_app_12_201912.png)
 
 Select the test device to delete on the Search Test Device screen and click the Delete button located at the top left of the screen to delete the test device information. Once deleted, the information cannot be recovered, so please make sure that it needs to be deleted before clicking the button.
 
@@ -742,19 +742,19 @@ They are divided by user level (INT), world/server/channel, and class/profession
 ### By User Level (INT)
 Can check the level indexes transferred to the Analytics system.
 In this item, only search is available, without separate edits.
-![gamebase_app_20_201812.png] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_01_202003.png)
+![gamebase_app_20_201812.png](https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_01_202003.png)
 
 ### Search by World/Server/Channel and Class/Profession
 Currently, you can check the transfer index configured for each item.
 If you do not want to stack the indexes for the items configured in the Search screen, you can delete previously registered items using the Delete button.
 Deleted items are not displayed as indexes in the Analytics menu. Be careful when deleting items, as the indexes of deleted items won't be stacked anymore.
-![gamebase_app_20_201812.png] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_02_202003.png)
+![gamebase_app_20_201812.png](https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_02_202003.png)
 
 ### Register each World/Server/Channel and Class/Profession
 You can register new information that you want to stack in Analytics indexes.
 You can use the Add button below. **Up to 100 new items** can be registered.
 Only **those items displayed on the Index screen can be edited** among the previously registered data. If you want to delete them, you need to go to the Search screen and delete them there.
-![gamebase_app_20_201812.png] (https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_03_202003.png)
+![gamebase_app_20_201812.png](https://static.toastoven.net/prod_gamebase/gamebase_analytics_indicator_03_202003.png)
 
 #### (1) ChannelId/ClassId: Enter the information of the separator to be stacked in Analytics. Enter the ID information you want to set when stacking indexes.
 #### (2) Display index screen: Type in text to display when displaying the index that was transferred to the ID entered as the first item. The information can be used to edit already registered indexes.

--- a/en/release-notes-android.md
+++ b/en/release-notes-android.md
@@ -367,7 +367,7 @@ The ZIP file for distribution no longer includes AAR files.
 
 #### Feature Updates
 * [SDK] 2.18.2
-    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-unity/#0213-20201124)
+    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-unity/#0213-20201124)
 	* (Android) External SDK update to resolve encryption logic security warnings: PAYCO Login SDK (1.5.3), Hangame ID SDK (1.3.2)
 	* (Android) Tencent Push module removed
 	* (Android) The deprecated function in Gamebase Android SDK 2.6.0 removed
@@ -386,7 +386,7 @@ The ZIP file for distribution no longer includes AAR files.
 
 #### Feature Updates
 * [SDK] 2.18.0
-    * (Android) TOAST SDK update: [Android(0.24.1)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-android/#0240-20201027) - Apply GooglePlay Billing Library v.3.0.1
+    * (Android) TOAST SDK update: [Android(0.24.1)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-android/#0240-20201027) - Apply GooglePlay Billing Library v.3.0.1
     * (Android) Added the response for WebView SSL security warnings
 
 #### Bug Fixes  

--- a/en/release-notes-console.md
+++ b/en/release-notes-console.md
@@ -319,7 +319,7 @@ Push > Push (Old) Console menu feature has been removed.
 	* Push > Push: Tencent Push removed
 	* Purchase (IAP) > Transaction information: Changed not to show the Check Receipt button in the refund state
 * [SDK] 2.18.2
-    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-unity/#0213-20201124)
+    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-unity/#0213-20201124)
 	* (Android) External SDK update to resolve encryption logic security warnings: PAYCO Login SDK (1.5.3), Hangame ID SDK (1.3.2)
 	* (Android) Tencent Push module removed
 	* (Android) The deprecated function in Gamebase Android SDK 2.6.0 removed
@@ -365,7 +365,7 @@ Push > Push (Old) Console menu feature has been removed.
 
 #### Feature Updates
 * [SDK] 2.18.0
-    * (Android) TOAST SDK update: [Android(0.24.1)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-android/#0240-20201027) - Apply GooglePlay Billing Library v.3.0.1
+    * (Android) TOAST SDK update: [Android(0.24.1)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-android/#0240-20201027) - Apply GooglePlay Billing Library v.3.0.1
     * (Android) Added the response for WebView SSL security warnings
     * (iOS) Added API that supports the SceneDelegate of iOS 13 or higher
 
@@ -444,7 +444,7 @@ Contact our Customer Center if you want to use the Hangame authentication.
 #### Feature Updates
 * [SDK] 2.15.1
     * (iOS) TOAST SDK update: iOS(0.27.0)
-	* A new version of IAP SDK is applied to support the changes made to iOS 14 beta. [TOAST SDK Release Notes](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-ios/#0270-20200911)
+	* A new version of IAP SDK is applied to support the changes made to iOS 14 beta. [TOAST SDK Release Notes](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-ios/#0270-20200911)
 
 ### September 15, 2020
 
@@ -474,7 +474,7 @@ you may encounter an issue during reprocessing if a different billing client ver
     * (Common) Added Push API: Check token information of a push (Gamebase.Push.queryTokenInfo API)
 * [SDK] 2.9.1
     * (Unreal) Supports Unreal 4.22 ~ 4.25
-    * (Unreal) Supports PLCrashReporter Issue: [Guide](http://docs.toast.com/ko/Game/Gamebase/ko/unreal-started/#ios-settings)
+    * (Unreal) Supports PLCrashReporter Issue: [Guide](http://docs.toast.com/en/Game/Gamebase/en/unreal-started/#ios-settings)
 
 #### Feature Updates
 * [Console]

--- a/en/release-notes-ios.md
+++ b/en/release-notes-ios.md
@@ -335,7 +335,7 @@ Changed the minimum supported version of the XCode of Gamebase from ver. 10 to 1
 
 #### Feature Updates
 * [SDK] 2.18.2
-    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-unity/#0213-20201124)
+    * (Common) TOAST SDK update: [Android(0.24.2)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-android/#0242-20201124), [iOS(0.27.1)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-ios/#0271-20201124), [Unity(0.21.3)](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-unity/#0213-20201124)
     * (iOS) showWebView: Returns error when invalid URL is delivered, delivered URL is used as is without encoding
     * (iOS) Changed to run the custom scheme regardless of letter case
 
@@ -390,7 +390,7 @@ Contact our Customer Center if you want to use the Hangame authentication.
 #### Feature Updates
 * [SDK] 2.15.1
     * (iOS) TOAST SDK update: iOS(0.27.0)
-    * A new version of IAP SDK is applied to support the changes made to iOS 14 beta. [TOAST SDK Release Notes](https://docs.toast.com/ko/TOAST/ko/toast-sdk/release-notes-ios/#0270-20200911)
+    * A new version of IAP SDK is applied to support the changes made to iOS 14 beta. [TOAST SDK Release Notes](https://docs.toast.com/en/TOAST/en/toast-sdk/release-notes-ios/#0270-20200911)
 
 ### 2.15.0 (2020.08.25)
 [SDK Download](https://static.toastoven.net/toastcloud/sdk_download/gamebase/v2.15.0/GamebaseSDK-iOS.zip)

--- a/en/unity-etc.md
+++ b/en/unity-etc.md
@@ -1082,7 +1082,7 @@ Gamebase provides features to respond to customer inquiries.
 >
 > Associate it with the NHN Cloud Contact service to easily respond to inquiries from customers.
 > See the guide below if you want to know how to use the NHN Cloud Contact service in detail.
-> [NHN Cloud Online Contact Guide] (/Contact%20Center/ko/online-contact-overview/)
+> [NHN Cloud Online Contact Guide](/Contact%20Center/en/online-contact-overview/)
 
 #### Customer Service Type
 


### PR DESCRIPTION
- Remove unnecessary whitespace in link and image syntax
- Change language path in links to */en* for English version